### PR TITLE
Modify parse-line function

### DIFF
--- a/src/cl-ltsv.lisp
+++ b/src/cl-ltsv.lisp
@@ -28,10 +28,10 @@
 (defun parse-line (s)
   (loop
      for kv in (split-sequence #\tab s)
-     collect (let* ((lis (split-sequence #\: kv))
-                    (k (car lis))
-                    (v (cadr lis)))
-               (cons k v))))
+     collect (let ((pos (position-if-c #\: kv)))
+	       (if pos
+		   (cons (subseq kv 0 pos)
+			 (subseq kv (1+ pos)))))))
 
 (defmacro with-ltsv-from-stream ((entry stream) &body body)
   (let ((line (gensym)))


### PR DESCRIPTION
Code:
(cl-ltsv:parse-line "url:http://ltsv.org")
Actually:
(("url" . "http"))
but I expected:
(("url" . "http://ltsv.org"))

According to http://ltsv.org/#abnf, it seems that colon character may be involved in 'field-value'.
So, I modified cl-ltsv:parse-line function. Please check it, and sorry for my poor English. 
Thank you.
